### PR TITLE
fix: regressions regarding tungstenite

### DIFF
--- a/src/implementations/channel/channel.rs
+++ b/src/implementations/channel/channel.rs
@@ -19,7 +19,7 @@ impl Channel {
 
     /// Create a new channel from it's channel id.
     pub async fn from_id(rest: RestClient, channel_id: &String) -> Result<Self, Box<dyn Error>> {
-        let res = rest.get(&format!("channels/{}", channel_id)).await?;
+        let res = rest.get(&format!("channels/{channel_id}")).await?;
         let channel = res.json::<ChannelApiType>().await?;
         Ok(Channel::from_api_type(rest, channel))
     }

--- a/src/implementations/channel/message/message.rs
+++ b/src/implementations/channel/message/message.rs
@@ -18,10 +18,7 @@ impl Message {
         Message {
             rest,
             msg,
-            channel: match channel {
-                Err(_) => None,
-                Ok(channel) => Some(channel),
-            },
+            channel: channel.ok(),
         }
     }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -13,7 +13,7 @@ pub struct RestClient {
 impl RestClient {
     pub fn new(bot_token: &str, api_version: u8) -> Self {
         Self {
-            base_url: format!("https://discord.com/api/v{}/", api_version),
+            base_url: format!("https://discord.com/api/v{api_version}/"),
             bot_token: bot_token.to_owned(),
             client: reqwest::Client::new(),
         }


### PR DESCRIPTION
This commit introduces several improvements to the WebSocket connection handling in the
disruption_gateway crate:

- Simplify the URL parsing for the WebSocket connection by using the `into_client_request()`
  method instead of manually parsing the URL.
- Improve the handling of `Message::Text` and `Message::Ping` messages by converting the
  payloads to `String` and `Vec<u8>` respectively, to ensure consistent handling.
- Improve the error message when there's an issue sending the heartbeat.
- Simplify the `static_send_message()` function by using `Message::Text(message.into())`
  instead of manually creating a `Message::Text` variant.

These changes aim to make the code more readable, maintainable, and robust.